### PR TITLE
misc: packaging fixes

### DIFF
--- a/debian/dirs
+++ b/debian/dirs
@@ -1,6 +1,1 @@
-usr/bin
-usr/sbin
-usr/lib
-usr/lib/pkgconfig
-usr/include
-etc/ganesha
+var/log/ganesha

--- a/debian/rules
+++ b/debian/rules
@@ -68,6 +68,7 @@ override_dh_install:
 	cp src/config_samples/gpfs.ganesha.main.conf debian/tmp/etc/ganesha/gpfs.ganesha.main.conf
 	cp src/config_samples/gpfs.ganesha.nfsd.conf debian/tmp/etc/ganesha/gpfs.ganesha.nfsd.conf
 	cp src/config_samples/logrotate_ganesha debian/tmp/etc/logrotate.d/nfs-ganesha
+	cp src/scripts/systemd/nfs-ganesha.service.debian8 src/scripts/systemd/nfs-ganesha.service
 	cp src/scripts/systemd/nfs-ganesha* debian/tmp/lib/systemd/system/
 	cp src/scripts/systemd/sysconfig/nfs-ganesha debian/tmp/etc/default/
 	cp src/scripts/ganeshactl/org.ganesha.nfsd.conf debian/tmp/etc/dbus-1/system.d/nfs-ganesha-dbus.conf


### PR DESCRIPTION
* Have packages create a /var/log/ganesha directory
* Have packages install a nfs-ganesha.service file
which is identical to nfs-ganesha.service.debian8
* Remove /etc/ganesha from dirs since none of the
files under /etc the nfs-ganesha package was
installing were being installed

Signed-off-by: Ali Maredia <amaredia@redhat.com>