### PR TITLE
correct FSAL subpackage descriptions

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -92,7 +92,7 @@ Architecture: any
 Section: libs
 Depends: ${misc:Depends}, ${shlibs:Depends},
          nfs-ganesha (=${binary:Version})
-Description: nfs-ganesha fsal ceph libraries
+Description: nfs-ganesha fsal vfs libraries
  NFS-GANESHA is a NFS Server running in user space with a large cache.
  It comes with various backend modules to support different file systems
  and namespaces. Supported name spaces are POSIX, PROXY, SNMP, FUSE-like,
@@ -105,12 +105,12 @@ Architecture: any
 Section: libs
 Depends: ${misc:Depends}, ${shlibs:Depends},
          nfs-ganesha (=${binary:Version})
-Description: nfs-ganesha fsal ceph libraries
+Description: nfs-ganesha fsal xfs libraries
  NFS-GANESHA is a NFS Server running in user space with a large cache.
  It comes with various backend modules to support different file systems
  and namespaces. Supported name spaces are POSIX, PROXY, SNMP, FUSE-like,
  HPSS, LUSTRE, XFS and ZFS.
- This package contains a library for a FSAL_XFS and an example vfs.conf file
+ This package contains a library for a FSAL_XFS and an example xfs.conf file
 
 Package: nfs-ganesha-mem
 Multi-Arch: same
@@ -118,7 +118,7 @@ Architecture: any
 Section: libs
 Depends: ${misc:Depends}, ${shlibs:Depends},
          nfs-ganesha (=${binary:Version})
-Description: nfs-ganesha fsal ceph libraries
+Description: nfs-ganesha fsal mem libraries
  NFS-GANESHA is a NFS Server running in user space with a large cache.
  It comes with various backend modules to support different file systems
  and namespaces. Supported name spaces are POSIX, PROXY, SNMP, FUSE-like,
@@ -131,7 +131,7 @@ Architecture: any
 Section: libs
 Depends: ${misc:Depends}, ${shlibs:Depends},
          nfs-ganesha (=${binary:Version})
-Description: nfs-ganesha fsal ceph libraries
+Description: nfs-ganesha fsal nullfs libraries
  NFS-GANESHA is a NFS Server running in user space with a large cache.
  It comes with various backend modules to support different file systems
  and namespaces. Supported name spaces are POSIX, PROXY, SNMP, FUSE-like,
@@ -144,7 +144,7 @@ Architecture: any
 Section: libs
 Depends: ${misc:Depends}, ${shlibs:Depends},
          nfs-ganesha (=${binary:Version})
-Description: nfs-ganesha fsal ceph libraries
+Description: nfs-ganesha fsal proxy libraries
  NFS-GANESHA is a NFS Server running in user space with a large cache.
  It comes with various backend modules to support different file systems
  and namespaces. Supported name spaces are POSIX, PROXY, SNMP, FUSE-like,
@@ -157,7 +157,7 @@ Architecture: any
 Section: libs
 Depends: ${misc:Depends}, ${shlibs:Depends},
          nfs-ganesha (=${binary:Version})
-Description: nfs-ganesha fsal ceph libraries
+Description: nfs-ganesha fsal gpfs libraries
  NFS-GANESHA is a NFS Server running in user space with a large cache.
  It comes with various backend modules to support different file systems
  and namespaces. Supported name spaces are POSIX, PROXY, SNMP, FUSE-like,


### PR DESCRIPTION
The ceph FSAL description was copied & pasted for all of the other FSAL sub-packages. Correct the descriptions for each FSAL subpackage to reflect the contents.