### PR TITLE
Enable RADOS based features

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -39,7 +39,9 @@ override_dh_auto_configure:
 		-DUSE_FSAL_VFS=ON \
 		-DUSE_FSAL_PROXY=OFF \
 		-DUSE_9P=OFF \
-		-DDISTNAME_HAS_GIT_DATA=OFF
+		-DDISTNAME_HAS_GIT_DATA=OFF \
+		-DRADOS_URLS=ON \
+		-DUSE_RADOS_RECOV=ON
 
 override_dh_auto_test:
 


### PR DESCRIPTION
Enable RADOS KV recovery, and config file inclusion from
RADOS objects features, introduced in NFS-Ganesha v.2.6.

Signed-off-by: Ramana Raja <rraja@redhat.com>