### PR TITLE
debian/control: install missing lttng library

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -22,6 +22,7 @@ Build-Depends: debhelper (>= 9),
                libcephfs-dev,
                pkgconf,
                liblttng-ust-dev
+               liblttng-ctl-dev
 Vcs-Git: https://github.com/nfs-ganesha/nfs-ganesha.git
 
 Package: nfs-ganesha


### PR DESCRIPTION
... to allow building nfs-ganesha with cmake flag -DUSE_LTTNG

Signed-off-by: Ramana Raja <rraja@redhat.com>