### PR TITLE
debian/nfs-ganesha.install: add libganesha_nfsd.so

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -29,6 +29,7 @@ Vcs-Git: https://github.com/nfs-ganesha/nfs-ganesha.git
 Package: nfs-ganesha
 Architecture: any
 Depends: dbus, nfs-common, rpcbind,
+         ${shlib:Depends},
          ${perl:Depends},
          ${misc:Depends},
          libwbclient0,

--- a/debian/nfs-ganesha.install
+++ b/debian/nfs-ganesha.install
@@ -9,3 +9,4 @@ config_samples/* usr/share/doc/nfs-ganesha-doc/config_samples/
 usr/include/ntirpc/*
 usr/lib/pkgconfig/libntirpc.pc
 usr/lib/libntirpc.so*
+usr/lib/libganesha_nfsd.so*


### PR DESCRIPTION
debian/control: update dependencies with ${shlib:Depends}

Note: V2.8-dev.23 introduced libganesha_nfsd as a DSO, and this broke the daily nfs-ganesha Ubuntu dev builds at jenkins.ceph.com.